### PR TITLE
Fix numeric parsing and audit logging

### DIFF
--- a/clients/audit_client.py
+++ b/clients/audit_client.py
@@ -17,7 +17,7 @@ class AuditClient:
             "Status": status,
             "StatusType": status_type,
             "TimeStamp": now_readable(),
-            "Projectumber": project_no,
+            "ProjectNumber": project_no,
             "RecordNumber": record_no,
             "linkId": link_id,
             "IntegrationStatus": integration_status,
@@ -25,4 +25,10 @@ class AuditClient:
             "path": path,
             "Payload": json.dumps(payload)
         }
-        return requests.post(self.url, json=body)
+        print(f"AuditClient.log -> POST {self.url} payload: {body}")
+        resp = requests.post(self.url, json=body)
+        print(
+            "AuditClient.log <-",
+            f"status {getattr(resp, 'status_code', 'unknown')} response: {getattr(resp, 'text', '')}",
+        )
+        return resp

--- a/clients/fusion_receipt_client.py
+++ b/clients/fusion_receipt_client.py
@@ -54,6 +54,13 @@ class FusionReceiptClient:
                 }
             ]
         }
+        print(
+            f"FusionReceiptClient.create_receipt -> POST {self.url} payload: {payload}"
+        )
         resp = requests.post(self.url, json=payload, auth=self.auth, headers=self.headers)
+        print(
+            "FusionReceiptClient.create_receipt <-",
+            f"status {getattr(resp, 'status_code', 'unknown')} response: {getattr(resp, 'text', '')}",
+        )
         raw = resp.json() if resp.ok else {}
         return payload, ReceiptResult(raw)

--- a/clients/fusion_validation_client.py
+++ b/clients/fusion_validation_client.py
@@ -19,6 +19,11 @@ class FusionValidationClient:
             "projectNumber": record.c10,
             "poLineNum": record.c4
         }
+        print(f"FusionValidationClient.validate_po -> POST {self.url} payload: {payload}")
         resp = requests.post(self.url, json=payload)
+        print(
+            "FusionValidationClient.validate_po <-",
+            f"status {getattr(resp, 'status_code', 'unknown')} response: {getattr(resp, 'text', '')}",
+        )
         raw = resp.json() if resp.ok else {}
         return payload, ValidationResult(raw)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 apscheduler
 python-dotenv
+Flask

--- a/test_clients.py
+++ b/test_clients.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+
+from clients.unifier_client import Record
+from clients.audit_client import AuditClient
+
+
+def test_record_handles_none_values():
+    r = Record({"c3": None, "c7": None, "c10": "p", "c11": "r"})
+    assert r.c3 == 0.0
+    assert r.c7 == 0.0
+
+
+def test_audit_client_uses_correct_project_number_key():
+    client = AuditClient()
+    with patch("requests.post") as post:
+        client.log("id", "step", "status", "type", "prj", "rec", "",
+                   "INT", "1", "path", {"a": 1})
+        body = post.call_args.kwargs["json"]
+        assert "ProjectNumber" in body
+        assert "Projectumber" not in body


### PR DESCRIPTION
## Summary
- Improve Unifier record parsing to handle `None` and comma-formatted numeric fields
- Use correct status label in Unifier query and send `ProjectNumber` in audit payloads
- Add tests for numeric parsing and audit logging
- Print API request/response details and step progress for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f54c07e28832896a1b0d152133e69